### PR TITLE
chore(hardware): set revision to v1.0.0

### DIFF
--- a/hardware/txe8116-module/kicad/txe8116-module.kicad_pcb
+++ b/hardware/txe8116-module/kicad/txe8116-module.kicad_pcb
@@ -8,6 +8,7 @@
 	)
 	(paper "A4")
 	(title_block
+		(rev "v1.0.0")
 		(comment 4 "AISLER Project ID: ZZLMEGJE")
 	)
 	(layers

--- a/hardware/txe8116-module/kicad/txe8116-module.kicad_sch
+++ b/hardware/txe8116-module/kicad/txe8116-module.kicad_sch
@@ -4,6 +4,9 @@
 	(generator_version "9.0")
 	(uuid "07123eb2-095c-4276-b37d-21a84783f032")
 	(paper "A4")
+	(title_block
+		(rev "v1.0.0")
+	)
 	(lib_symbols
 		(symbol "Connector_Generic:Conn_01x12"
 			(pin_names


### PR DESCRIPTION
Sets revision field in PCB and schematic title blocks so generated artefact filenames include the version.