### PR TITLE
ci: add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/hardware-ci.yml
+++ b/.github/workflows/hardware-ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   erc-drc:


### PR DESCRIPTION
Allows manual triggering of the hardware CI workflow.